### PR TITLE
Update pf_q-vlan.h

### DIFF
--- a/kernel/pf_q-vlan.h
+++ b/kernel/pf_q-vlan.h
@@ -31,7 +31,7 @@
 
 extern struct sk_buff *pfq_vlan_untag(struct sk_buff *skb);
 
-#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,17,0))
+#elif (LINUX_VERSION_CODE < KERNEL_VERSION(3,16,6))
 
 static inline
 struct sk_buff *pfq_vlan_untag(struct sk_buff *skb)


### PR DESCRIPTION
Has the function
http://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/tree/include/linux/skbuff.h?h=linux-3.16.y&id=v3.16.6
don't
http://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/tree/include/linux/skbuff.h?h=linux-3.16.y&id=v3.16.5
thus a tighter bountd is fine