### PR TITLE
pfq-load: fix example config

### DIFF
--- a/user/pfq-load/pfq.example.conf
+++ b/user/pfq-load/pfq.example.conf
@@ -6,7 +6,7 @@ Config
 {
     pfq_module   = "/opt/PFQ/kernel/pfq.ko",                                                  
 
-    pfq_options  = [ "capture_incoming=0", "batch_len=32", "skb_pool_size=1024" ],
+    pfq_options  = [ "capture_incoming=0", "xmit_batch_len=32", "skb_pool_size=1024" ],
 
     exclude_core = [],
 


### PR DESCRIPTION
Looks like you meant xmit_batch_len in the example config as batch_len isn't a valid option.