### PR TITLE
Remove inline declarations from recursive functions

### DIFF
--- a/kernel/lang/signature.c
+++ b/kernel/lang/signature.c
@@ -195,7 +195,7 @@ pfq_lang_signature_simplify(string_view_t str)
 	return string_view_trim(str);
 }
 
-static inline
+static
 int __signature_arity(string_view_t s)
 {
 	string_view_t str  = pfq_lang_signature_simplify(s);
@@ -217,7 +217,7 @@ pfq_lang_signature_arity(string_view_t str)
 	return -1 + __signature_arity(str);
 }
 
-static inline
+static
 string_view_t __signature_bind(string_view_t s, int stop, int n)
 {
 	string_view_t str  = pfq_lang_signature_simplify(s),
@@ -241,7 +241,7 @@ pfq_lang_signature_bind(string_view_t str, int n)
 }
 
 
-static inline string_view_t
+static string_view_t
 __signature_arg(string_view_t s, int stop, int index)
 {
 	string_view_t str  = pfq_lang_signature_simplify(s);


### PR DESCRIPTION
This addresses: https://github.com/pfq/PFQ/issues/22

After trying to rewrite those function in an iterative manner, I realized that they are much less readable. A typical function signature shouldn't be two long anyway and I believe those arg-related functions are only called for sanity check when a computation is set so I think just removing `inline` would not affect performance much.