### PR TITLE
Make PFQ compile on linux kernel 4.6

### DIFF
--- a/kernel/pf_q-shmem.c
+++ b/kernel/pf_q-shmem.c
@@ -139,7 +139,7 @@ pfq_hugepage_unmap(struct pfq_shmem_descr *shmem)
 		if (!PageReserved(shmem->hugepages[i]))
 		    SetPageDirty(shmem->hugepages[i]);
 
-		page_cache_release(shmem->hugepages[i]);
+		put_page(shmem->hugepages[i]);
 	}
 
 	if (current->mm)

--- a/kernel/pf_q.c
+++ b/kernel/pf_q.c
@@ -240,7 +240,7 @@ pfq_receive_batch(struct pfq_percpu_data *data,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3,15,0))
 				if (bpf && !sk_run_filter(buff, bpf->insns))
 #else
-				if (bpf && !SK_RUN_FILTER(bpf, PFQ_SKB(buff)))
+				if (bpf && !BPF_PROG_RUN(bpf->prog, PFQ_SKB(buff)))
 #endif
 				{
 					__sparse_inc(this_group->stats, drop, cpu);


### PR DESCRIPTION
Some macros were removed so they are replaced with the equivalence in higher kernels